### PR TITLE
라이트노드-블록헤더에 함수 추가

### DIFF
--- a/Libplanet.Explorer/Store/LiteDBRichStore.cs
+++ b/Libplanet.Explorer/Store/LiteDBRichStore.cs
@@ -194,6 +194,12 @@ namespace Libplanet.Explorer.Store
             _blockCache.AddOrUpdate(block.Hash, block.ToBlockDigest());
         }
 
+        /// <inheritdoc cref="IStore.PutBlockHeader(BlockHeader)"/>
+        public void PutBlockHeader(BlockHeader blockHeader)
+        {
+            throw new NotSupportedException();
+        }
+
         /// <inheritdoc cref="IStore.ListChainIds()"/>
         public IEnumerable<Guid> ListChainIds()
         {

--- a/Libplanet.Explorer/Store/MySQLRichStore.cs
+++ b/Libplanet.Explorer/Store/MySQLRichStore.cs
@@ -156,6 +156,12 @@ namespace Libplanet.Explorer.Store
             }
         }
 
+        /// <inheritdoc cref="IStore.PutBlockHeader(BlockHeader)"/>
+        public void PutBlockHeader(BlockHeader blockHeader)
+        {
+            throw new NotSupportedException();
+        }
+
         /// <inheritdoc cref="IStore.ListChainIds()"/>
         public IEnumerable<Guid> ListChainIds()
         {

--- a/Libplanet.RocksDBStore/MonoRocksDBStore.cs
+++ b/Libplanet.RocksDBStore/MonoRocksDBStore.cs
@@ -488,6 +488,12 @@ namespace Libplanet.RocksDBStore
             _blockCache.AddOrUpdate(block.Hash, block.ToBlockDigest());
         }
 
+        /// <inheritdoc/>
+        public override void PutBlockHeader(BlockHeader blockHeader)
+        {
+            throw new NotSupportedException();
+        }
+
         /// <inheritdoc cref="BaseStore.DeleteBlock(BlockHash)"/>
         public override bool DeleteBlock(BlockHash blockHash)
         {

--- a/Libplanet.RocksDBStore/RocksDBStore.cs
+++ b/Libplanet.RocksDBStore/RocksDBStore.cs
@@ -23,6 +23,7 @@ namespace Libplanet.RocksDBStore
     /// <seealso cref="IStore"/>
     public class RocksDBStore : BaseStore
     {
+        private const string BlockHeaderDbPathName = "blockheader";
         private const string BlockDbRootPathName = "block";
         private const string BlockIndexDbName = "blockindex";
         private const string BlockPerceptionDbName = "blockpercept";

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -250,8 +250,10 @@ namespace Libplanet.Blocks
 
         /// <summary>
         /// Convert <see cref="string"/> type of
-        /// <param name="timeStamp"></param> to <see cref="DateTimeOffset"/>.
+        /// timeStamp to <see cref="DateTimeOffset"/>.
         /// </summary>
+        /// <param name="timeStamp"> the time
+        /// when block header was created.</param>
         /// <returns><see cref="DateTimeOffset"/> representation of
         /// <see cref="BlockHeader.Timestamp"/>.</returns>
         public DateTimeOffset ParseDateTimeOffset(string timeStamp)

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -267,6 +267,77 @@ namespace Libplanet.Blocks
             }
         }
 
+        public override bool Equals(object obj)
+        {
+            if ((obj is null) || !(obj is BlockHeader))
+            {
+                return false;
+            }
+
+            BlockHeader blockHeader = (BlockHeader)obj;
+            if (!this.ProtocolVersion.Equals(blockHeader.ProtocolVersion))
+            {
+                return false;
+            }
+
+            if (!this.Index.Equals(blockHeader.Index))
+            {
+                return false;
+            }
+
+            if (!this.Timestamp.Equals(blockHeader.Timestamp))
+            {
+                return false;
+            }
+
+            if (!this.Nonce.SequenceEqual(blockHeader.Nonce))
+            {
+                return false;
+            }
+
+            if (!this.Miner.SequenceEqual(blockHeader.Miner))
+            {
+                return false;
+            }
+
+            if (!this.Difficulty.Equals(blockHeader.Difficulty))
+            {
+                return false;
+            }
+
+            if (!this.TotalDifficulty.Equals(blockHeader.TotalDifficulty))
+            {
+                return false;
+            }
+
+            if (!this.PreviousHash.SequenceEqual(blockHeader.PreviousHash))
+            {
+                return false;
+            }
+
+            if (!this.TxHash.SequenceEqual(blockHeader.TxHash))
+            {
+                return false;
+            }
+
+            if (!this.Hash.SequenceEqual(blockHeader.Hash))
+            {
+                return false;
+            }
+
+            if (!this.PreEvaluationHash.SequenceEqual(blockHeader.PreEvaluationHash))
+            {
+                return false;
+            }
+
+            if (!this.StateRootHash.SequenceEqual(blockHeader.StateRootHash))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         internal static byte[] SerializeForHash(
             int protocolVersion,
             long index,

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -338,6 +338,14 @@ namespace Libplanet.Blocks
             return true;
         }
 
+        public override int GetHashCode()
+        {
+            return PreviousHash.GetHashCode() ^
+                TxHash.GetHashCode() ^
+                Hash.GetHashCode() ^
+                StateRootHash.GetHashCode();
+        }
+
         internal static byte[] SerializeForHash(
             int protocolVersion,
             long index,

--- a/Libplanet/Blocks/BlockHeader.cs
+++ b/Libplanet/Blocks/BlockHeader.cs
@@ -248,6 +248,25 @@ namespace Libplanet.Blocks
             return dict;
         }
 
+        /// <summary>
+        /// Convert <see cref="string"/> type of
+        /// <param name="timeStamp"></param> to <see cref="DateTimeOffset"/>.
+        /// </summary>
+        /// <returns><see cref="DateTimeOffset"/> representation of
+        /// <see cref="BlockHeader.Timestamp"/>.</returns>
+        public DateTimeOffset ParseDateTimeOffset(string timeStamp)
+        {
+            if (timeStamp == "0000-00-00" ||
+                DateTimeOffset.TryParse(timeStamp, out DateTimeOffset output))
+            {
+                return DateTimeOffset.Now;
+            }
+            else
+            {
+                return output;
+            }
+        }
+
         internal static byte[] SerializeForHash(
             int protocolVersion,
             long index,

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -490,6 +490,10 @@ namespace Libplanet.Net
         /// A cancellation token used to propagate notification that this
         /// operation should be canceled.
         /// </param>
+        /// <param name="lightNode">
+        /// A boolean instance that checks whether this is light node or not.
+        /// If it were true, You'll get only block headers while preloading.
+        /// </param>
         /// <returns>
         /// A task without value.
         /// You only can <c>await</c> until the method is completed.
@@ -505,7 +509,8 @@ namespace Libplanet.Net
         public async Task PreloadAsync(
             TimeSpan? dialTimeout = null,
             IProgress<PreloadState> progress = null,
-            CancellationToken cancellationToken = default(CancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken),
+            bool lightNode = default(bool)
         )
         {
             using CancellationTokenRegistration ctr = cancellationToken.Register(() =>

--- a/Libplanet/Net/Swarm.cs
+++ b/Libplanet/Net/Swarm.cs
@@ -684,35 +684,53 @@ namespace Libplanet.Net
                             )
                         );
                     }
-
-                    _logger.Verbose(
-                        "Add a block #{BlockIndex} {BlockHash}...",
-                        block.Index,
-                        block.Hash
-                    );
-                    block.Validate(DateTimeOffset.UtcNow);
-                    wStore.PutBlock(block);
-                    if (tempTip is null || block.Index > tempTip.Index)
+                    if (lightNode)
                     {
-                        tempTip = block;
+                        _logger.Verbose(
+                            "Add a blockHeader of block #{BlockIndex} {BlockHash}...",
+                            block.Index,
+                            block.Hash
+                        );
+                        wStore.PutBlockHeader(block.Header);
+                        _logger.Debug(
+                            "Stored a blockHeader of block #{BlockIndex} {BlockHash} " +
+                            "into the store.",
+                            block.Index,
+                            block.Hash
+                        );
+                        return;
                     }
-
-                    receivedBlockCount++;
-                    progress?.Report(new BlockDownloadState
+                    else 
                     {
-                        TotalBlockCount = Math.Max(
-                            totalBlocksToDownload,
-                            receivedBlockCount),
-                        ReceivedBlockCount = receivedBlockCount,
-                        ReceivedBlockHash = block.Hash,
-                        SourcePeer = sourcePeer,
-                    });
-                    _logger.Debug(
-                        "Appended a block #{BlockIndex} {BlockHash} " +
-                        "to the workspace chain.",
-                        block.Index,
-                        block.Hash
-                    );
+                        _logger.Verbose(
+                            "Add a block #{BlockIndex} {BlockHash}...",
+                            block.Index,
+                            block.Hash
+                        );
+                        block.Validate(DateTimeOffset.UtcNow);
+                        wStore.PutBlock(block);
+                        if (tempTip is null || block.Index > tempTip.Index)
+                        {
+                            tempTip = block;
+                        }
+
+                        receivedBlockCount++;
+                        progress?.Report(new BlockDownloadState
+                        {
+                            TotalBlockCount = Math.Max(
+                                totalBlocksToDownload,
+                                receivedBlockCount),
+                            ReceivedBlockCount = receivedBlockCount,
+                            ReceivedBlockHash = block.Hash,
+                            SourcePeer = sourcePeer,
+                        });
+                        _logger.Debug(
+                            "Appended a block #{BlockIndex} {BlockHash} " +
+                            "to the workspace chain.",
+                            block.Index,
+                            block.Hash
+                        );                        
+                    }                    
                 }
 
                 tipCandidate = tempTip;

--- a/Libplanet/Store/BaseStore.cs
+++ b/Libplanet/Store/BaseStore.cs
@@ -123,6 +123,9 @@ namespace Libplanet.Store
         public abstract void PutBlock<T>(Block<T> block)
             where T : IAction, new();
 
+        /// <inheritdoc />
+        public abstract void PutBlockHeader(BlockHeader blockHeader);
+
         /// <inheritdoc cref="IStore.DeleteBlock(BlockHash)"/>
         public abstract bool DeleteBlock(BlockHash blockHash);
 

--- a/Libplanet/Store/DefaultStore.cs
+++ b/Libplanet/Store/DefaultStore.cs
@@ -468,6 +468,12 @@ namespace Libplanet.Store
             _blockCache.AddOrUpdate(block.Hash, block.ToBlockDigest());
         }
 
+        /// <inheritdoc/>
+        public override void PutBlockHeader(BlockHeader blockHeader)
+        {
+            throw new NotSupportedException();
+        }
+
         /// <inheritdoc cref="BaseStore.DeleteBlock(BlockHash)"/>
         public override bool DeleteBlock(BlockHash blockHash)
         {

--- a/Libplanet/Store/IStore.cs
+++ b/Libplanet/Store/IStore.cs
@@ -174,6 +174,12 @@ namespace Libplanet.Store
             where T : IAction, new();
 
         /// <summary>
+        /// Puts the given <paramref name="blockHeader"/> in to the store.
+        /// </summary>
+        /// <param name="blockHeader">A <see cref="BlockHeader"/> to put into the store.</param>
+        void PutBlockHeader(BlockHeader blockHeader);
+
+        /// <summary>
         /// Removes a block from the store.
         /// </summary>
         /// <param name="blockHash">The hash of a block to remove.</param>


### PR DESCRIPTION
[53880df](https://github.com/planetarium/libplanet/commit/53880df4914474d6ca28676079669f8ea6a6cc94)
[39f2121](https://github.com/planetarium/libplanet/commit/39f21218aaa8de0f5c3704f307e8ebfb2a8954de)
[6ef36a9](https://github.com/planetarium/libplanet/commit/6ef36a9c1bcdb4dade626331ae8b1b5c0d9291fb)
[49a80e5](https://github.com/planetarium/libplanet/commit/49a80e5ffa2fd0ed62f1a475ceea33037f39af57)
4개 커밋만 해당됩니다. 

블록헤더는 블록과 달리 `string`으로 timestamp를 저장하고 있어 `DateTimeOffset`으로 변환하는 함수 추가함
블록헤더 간 비교를 위한 Equals 함수 추가함